### PR TITLE
pagination issues

### DIFF
--- a/src/PaginationMenu/index.js
+++ b/src/PaginationMenu/index.js
@@ -182,7 +182,14 @@ export default class PaginationMenu extends React.Component {
   // Important - this is needed to ensure changes to main properties
   // are propagated down to our component.
   componentWillReceiveProps(nextProps) {
-    this.setState({ numMatches: nextProps.numMatches });
+    const { numMatches } = this.state;
+    console.log('numMatches changed from: ' + numMatches + ' to: ' + nextProps.numMatches);
+    if (numMatches != nextProps.numMatches) {
+      this.setState({
+        numMatches: nextProps.numMatches,
+        currentPage: '1'
+      });
+    }
   }
 
   render() {

--- a/src/main.js
+++ b/src/main.js
@@ -179,6 +179,7 @@ class Main extends React.Component {
     
     this.setState({
       loading: true,
+      currentPage: '1',
       searchQuery
     });
 
@@ -293,7 +294,8 @@ class Main extends React.Component {
     if (!data) {
       return null;
     }
-    var page = Number(currentPage);
+
+    var page = parseInt(currentPage);
     var startIdx = (page - 1) * utils.ITEMS_PER_PAGE;
     return (
       <Matches 


### PR DESCRIPTION
- fixed problem where matches shown were out of sync, had to reset currentPage = 1 when filters where selected by user
- no remnants of a pagination menu show up now if there is only one page of data
- currentPage is set to '1' when 'numMatches' changes
 