### PR TITLE
fixes to chart processing

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,7 +42,7 @@ const WatsonDiscoServer = new Promise((resolve, reject) => {
       // this is the inital query to the discovery service
       const params = queryBuilder.search({ 
         natural_language_query: '',
-        count: 1000
+        count: 5000
       });
       return new Promise((resolve, reject) => {
         discovery.query(params)
@@ -75,13 +75,20 @@ function createServer(results) {
 
   // handles search request from search bar
   server.get('/api/trending', (req, res) => {
-    const { query } = req.query;
+    const { query, filters, count } = req.query;
 
     console.log('In /api/trending: query = ' + query);
     
     // build params for the trending search request
     var params = {};
     params.query = query;
+
+    // add any filters and a limit to the number of matches that can be found
+    if (filters) {
+      params.filter = filters;
+    }
+    params.count = count;
+
     var searchParams = queryTrendBuilder.search(params);
     discovery.query(searchParams)
       .then(response => res.json(response))

--- a/server/query-builder-trending.js
+++ b/server/query-builder-trending.js
@@ -29,8 +29,7 @@ module.exports = {
       collection_id: this.collection_id,
       deduplicate: true,
       sort: 'date',
-      aggregation: 'timeslice(date,1month).average(enriched_text.sentiment.document.score)',
-      count: 2000,
+      aggregation: 'timeslice(date,1month).average(enriched_text.sentiment.document.score)'
     }, queryOpts);
 
     console.log('Discovery Trending Query Params: ');

--- a/src/SearchField/index.js
+++ b/src/SearchField/index.js
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, Header, Grid, Input, Checkbox } from 'semantic-ui-react';
+import { Header, Grid, Input, Checkbox } from 'semantic-ui-react';
 const utils = require('../utils');
 
 /**
@@ -83,9 +83,6 @@ export default class SearchField extends React.Component {
       <Grid className='search-field-grid'>
         <Grid.Column width={12} verticalAlign='middle' textAlign='center'>
           <Header as='h1' textAlign='center'>
-            <Icon.Group size='large'>
-              <Icon name='hotel' />
-            </Icon.Group>
             Airbnb Review Data for Ausin, TX
           </Header>
           <Input

--- a/src/SentimentChart/index.js
+++ b/src/SentimentChart/index.js
@@ -103,7 +103,6 @@ export default class SentimentChart extends React.Component {
       keywords
     } = this.state;
     
-    // console.log('chartType: ' + chartType);
     if (chartType === utils.ENTITIY_FILTER) {
       this.getTotals(entities, termValue);
     } else if (chartType === utils.CATEGORY_FILTER) {
@@ -160,9 +159,17 @@ export default class SentimentChart extends React.Component {
    * modify the sentiment chart to just represent this term.
    */
   termTypeChange(event, selection) {
-    this.setState({
-      termValue: selection.value
-    });
+    const { termValue } = this.state;
+
+    // only update if term has actually changed
+    if (termValue != selection.value) {
+      this.setState({
+        termValue: selection.value
+      });
+      this.props.onSentimentTermChanged({
+        term: selection.value
+      });
+    }
   }
 
   /**
@@ -202,12 +209,15 @@ export default class SentimentChart extends React.Component {
     this.setState({ categories: nextProps.categories });
     this.setState({ concepts: nextProps.concepts });
     this.setState({ keywords: nextProps.keywords });
+    this.setState({ termValue: nextProps.term });
   }
 
   /**
    * render - return all the sentiment objects to render.
    */
   render() {
+    const { termValue } = this.state;
+
     const options = {
       responsive: true,
       legend: {
@@ -240,7 +250,7 @@ export default class SentimentChart extends React.Component {
           <Header.Content>
             Sentiment Chart
             <Header.Subheader>
-              Review sentiment by percentage
+              Sentiment scores by percentage
             </Header.Subheader>
           </Header.Content>
         </Header>
@@ -256,7 +266,7 @@ export default class SentimentChart extends React.Component {
           <Dropdown 
             item
             scrolling
-            defaultValue={ utils.TERM_ITEM }
+            value={ termValue }
             onChange={ this.termTypeChange.bind(this) }
             options={ this.getTermOptions() }
           />
@@ -282,5 +292,6 @@ SentimentChart.propTypes = {
   concepts: PropTypes.object,
   keywords: PropTypes.object,
   chartType: PropTypes.string,
-  termValue: PropTypes.string
+  term: PropTypes.string,
+  onSentimentTermChanged: PropTypes.func.isRequired,
 };

--- a/src/TrendChart/index.js
+++ b/src/TrendChart/index.js
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Grid, Header, Menu, Dropdown, Divider, Icon } from 'semantic-ui-react';
+import { Grid, Header, Menu, Dropdown, Divider, Icon } from 'semantic-ui-react';
 import { Line } from 'react-chartjs-2';
 const utils = require('../utils');
 
@@ -36,7 +36,7 @@ export default class TrendChart extends React.Component {
     super(...props);
 
     this.state = {
-      trendData: this.props.trendData || [],
+      trendData: this.props.trendData || null,
       trendLoading: this.props.trendLoading || false,
       trendError: this.props.trendError,
       entities: this.props.entities,
@@ -56,7 +56,7 @@ export default class TrendChart extends React.Component {
     this.setState({
       chartType: selection.value,
       termValue: utils.TERM_ITEM,
-      trendData: ''
+      trendData: null
     });
 
     this.props.onGetTrendDataRequest({
@@ -153,13 +153,14 @@ export default class TrendChart extends React.Component {
     this.setState({ categories: nextProps.categories });
     this.setState({ concepts: nextProps.concepts });
     this.setState({ keywords: nextProps.keywords });
+    this.setState({ termValue: nextProps.term });
   }
 
   /**
    * render - return the trending chart object to render.
    */
   render() {
-    const { trendLoading } = this.state;
+    const { trendLoading, termValue } = this.state;
     
     const options = {
       responsive: true,
@@ -191,16 +192,12 @@ export default class TrendChart extends React.Component {
           <Dropdown 
             item
             scrolling
-            defaultValue={ utils.TERM_ITEM }
+            value={ termValue }
+            loading={ trendLoading }
             onChange={ this.termTypeChange.bind(this) }
             options={ this.getTermOptions() }
           />
         </Menu>
-        {trendLoading ? (
-          <div>
-          <Button basic loading floated='right' size='large'>Loading</Button>
-          </div>
-        ) : null}
 
         <Divider clearing hidden/>
         <Grid.Row>
@@ -230,5 +227,6 @@ TrendChart.propTypes = {
   trendData: PropTypes.object,
   trendLoading: PropTypes.bool,
   trendError: PropTypes.object,
+  term: PropTypes.string,
   onGetTrendDataRequest: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
- fixed issues related to charts going back to default 'term' value when search or filter changed
- fixed issues related to chart drop down showing 'Term' when using default values
- limit number of results in trend chart query to match user preferences (limit results = 100)
- moving 'loading' spinner into drop down list in trend chart panel